### PR TITLE
Fix observable set cannot override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -   Add latest changes here
 
+## [v43.2.0-next.1](https://github.com/Multiverse-io/ckeditor5-math/compare/v43.2.0-next.0...v43.2.0-next.1) (2024-10-21)
+
+-   Fixes `CKEditorError: observable-set-cannot-override` error. See - https://ckeditor.com/docs/ckeditor5/latest/support/error-codes.html#error-observable-set-cannot-override
+
 ## [v43.2.0-next.0](https://github.com/Multiverse-io/ckeditor5-math/compare/v43.2.0...v43.2.0-next.0) (2024-10-21)
 
 -   Bootstrap CI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiverse-io/ckeditor5-math",
-  "version": "43.2.0-next.0",
+  "version": "43.2.0-next.1",
   "description": "Math feature for CKEditor 5.",
   "keywords": [
     "ckeditor",

--- a/src/ui/mathview.ts
+++ b/src/ui/mathview.ts
@@ -3,8 +3,8 @@ import type { KatexOptions } from '../typings-external.js';
 import { renderEquation } from '../utils.js';
 
 export default class MathView extends View {
-	public value: string;
-	public display: boolean;
+	public declare value: string;
+	public declare display: boolean;
 	public previewUid: string;
 	public previewClassName: Array<string>;
 	public katexRenderOptions: KatexOptions;
@@ -38,9 +38,7 @@ export default class MathView extends View {
 		this.previewClassName = previewClassName;
 
 		this.set( 'value', '' );
-		this.value = '';
 		this.set( 'display', false );
-		this.display = false;
 
 		this.on( 'change', () => {
 			if ( this.isRendered ) {


### PR DESCRIPTION
Fixes `CKEditorError: observable-set-cannot-override`. See - https://ckeditor.com/docs/ckeditor5/latest/support/error-codes.html#error-observable-set-cannot-override