### PR TITLE
Add Reef catalog and code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @Multiverse-io/lobsters will be requested for
+# review when someone opens a pull request.
+
+*       @Multiverse-io/lobsters

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ckeditor5-math
+  description: Math feature for CKEditor 5.
+  annotations:
+    github.com/project-slug: Multiverse-io/ckeditor5-math
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - typescript
+    - ckeditor5
+  links:
+    - title: GitHub
+      url: https://github.com/Multiverse-io/ckeditor5-math
+spec:
+  type: library
+  owner: lobsters
+  lifecycle: production


### PR DESCRIPTION
Resolves [LOB-1458](https://linear.app/multiverse-io/issue/LOB-1458).

# Changes

- Add `CODEOWNERS` for repository, set to lobsters
- Add `catalog-info.yaml` for package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds repository metadata/configuration (code ownership and catalog registration) with no runtime or production logic changes.
> 
> **Overview**
> Adds a `CODEOWNERS` file to default PR review requests to `@Multiverse-io/lobsters`.
> 
> Adds `catalog-info.yaml` to register `ckeditor5-math` in Backstage (component metadata, links, tags, owner, and lifecycle).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01b6213a82039ab60140340246113e6e7232e7b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->