### PR TITLE
Add base BugBot review rules scaffold

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,13 @@
+# CKEditor5 Math — Repo-Specific BugBot Rules
+
+> Org-wide rules are enforced via Cursor Team Rules.
+
+## CKEditor 5 Plugin
+
+- This is a CKEditor 5 plugin for math/equation rendering. It follows the CKEditor 5 plugin architecture with `src/` for source, `theme/` for styles, and `lang/` for translations.
+- TypeScript with multiple tsconfig files (dist, release, test). Ensure the correct config is used for each build target.
+- Changes are documented in `CHANGELOG.md`. Plugin metadata is in `ckeditor5-metadata.json`.
+
+## Testing
+
+- Tests are in `tests/` using CKEditor's testing infrastructure. Run tests before merging to validate editor integration.


### PR DESCRIPTION
## Summary

- Adds `.cursor/BUGBOT.md` with starter code review rules tailored to this repo's tech stack.
- These are base scaffolds — repo owners should review and customise the rules for their specific needs.
- BugBot will use these rules in addition to the org-wide team rules when reviewing PRs.

## What is this?

BugBot is Cursor's AI code reviewer. It reads `.cursor/BUGBOT.md` files to enforce repo-specific review standards. See the [BugBot Developer Handbook](https://multiverse-io.github.io/global-tech-docs/devex/bugbot/) for details.

## Next steps

- [ ] Review the generated rules — remove any that don't apply, add repo-specific ones
- [ ] Consider adding nested `.cursor/BUGBOT.md` files for distinct modules if needed