### PR TITLE
chore: transfer ownership to async-learning team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # @Multiverse-io/lobsters will be requested for
 # review when someone opens a pull request.
 
-*       @Multiverse-io/lobsters
+*       @Multiverse-io/async-learning @Multiverse-io/lobsters

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,5 +14,5 @@ metadata:
       url: https://github.com/Multiverse-io/ckeditor5-math
 spec:
   type: library
-  owner: lobsters
+  owner: async-learning
   lifecycle: production


### PR DESCRIPTION
## Summary

- Added `@Multiverse-io/async-learning` to `CODEOWNERS` alongside the existing `@Multiverse-io/lobsters` team
- Updated `catalog-info.yaml` owner from `lobsters` to `async-learning`

Part of the team ownership migration to async-learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that affects review routing and Backstage ownership, with no runtime behavior impact.
> 
> **Overview**
> Transfers repository ownership metadata to the `@Multiverse-io/async-learning` team.
> 
> Updates `CODEOWNERS` so `@Multiverse-io/async-learning` is requested for review alongside `@Multiverse-io/lobsters`, and changes `catalog-info.yaml` `spec.owner` from `lobsters` to `async-learning`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddfc3f8a216a7b447e50d3c6f256817f6924f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->